### PR TITLE
Upload debug apk artifact

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,15 +27,15 @@ jobs:
         build-tools-version: 33.0.2
         ndk-version: 25.1.8937393
 
-    - name: Make gradlew executable
-      run: chmod +x ./NDA-CALCULATOR/gradlew
-    - name: Make gradle-wrapper.jar executable
-      run: chmod +x ./NDA-CALCULATOR/gradle/wrapper/gradle-wrapper.jar
-
+    - name: Install Gradle 7.6.3
+      run: |
+        wget -q https://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+        unzip -q gradle-7.6.3-bin.zip -d $HOME/gradle
+        echo "$HOME/gradle/gradle-7.6.3/bin" >> $GITHUB_PATH
 
     - name: Build APK
       working-directory: NDA-CALCULATOR
-      run: ./gradlew assembleDebug
+      run: gradle assembleDebug
 
     - name: List build output files
       run: ls -R NDA-CALCULATOR/app/build/outputs || echo "Build outputs folder not found"


### PR DESCRIPTION
Install Gradle directly in CI and use it for building because the existing Gradle wrapper is broken.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f7f303c-f4f6-4c28-a8a1-da7e5c89d9f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4f7f303c-f4f6-4c28-a8a1-da7e5c89d9f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

